### PR TITLE
Use define-constant (instead of defconstant) with equal test

### DIFF
--- a/src/support_cl-json.lisp
+++ b/src/support_cl-json.lisp
@@ -1,10 +1,12 @@
 (in-package :cl-json-pointer)
 
-(defconstant +identifier-name-to-key-name+
-  (symbol-name '*identifier-name-to-key*))
+(define-constant +identifier-name-to-key-name+
+  (symbol-name '*identifier-name-to-key*)
+  :test #'equal)
 
-(defconstant +json-identifier-name-to-lisp-name+
-  (symbol-name '*json-identifier-name-to-lisp*))
+(define-constant +json-identifier-name-to-lisp-name+
+  (symbol-name '*json-identifier-name-to-lisp*)
+  :test #'equal)
 
 (defmethod intern-object-key ((flavor (eql :cl-json)) rtoken)
   ;; Do Like:


### PR DESCRIPTION
Hi, I wonder if you would consider this PR. There are a couple of defconstants that SBCL will error on because they were strings. Since the code already depends on Alexandria, I just changed cl:defconstant to alexandria:define-constant with #'equal as the test.

(example error)

```
debugger invoked on a SB-EXT:DEFCONSTANT-UNEQL in thread
#<THREAD "main thread" RUNNING {1004E50073}>:
  The constant +IDENTIFIER-NAME-TO-KEY-NAME+ is being redefined (from
  "*IDENTIFIER-NAME-TO-KEY*" to "*IDENTIFIER-NAME-TO-KEY*")
See also:
  The ANSI Standard, Macro DEFCONSTANT
  The SBCL Manual, Node "Idiosyncrasies"

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE                     ] Go ahead and change the value.
  1: [ABORT                        ] Keep the old value.
```